### PR TITLE
Corrections on the .env-sample mongo env-var

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,4 +1,4 @@
-MONGODB_URL=mongodb://localhost/reexpress
+MONGODB_URI=mongodb://localhost/reexpress
 JWT_SECRET=secretkeyhere
 HOST=http://localhost:3000
 EMAIL_HOST=


### PR DESCRIPTION
When directly copied the .env-sample to the .env file wont work since the mongo env variable is named different.